### PR TITLE
feat(actions): add auto labeling for branches

### DIFF
--- a/.github/pr-labeler-branches.yml
+++ b/.github/pr-labeler-branches.yml
@@ -1,0 +1,5 @@
+feature: ['feature/*', 'feat/*']
+fix: fix/*
+chore: chore/*
+refactor: refactor/*
+config: config/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler based on branch names
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler-branches.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub Action that automatically labels any PR when opened, based by
the branch name.

For instance, the branch `feature/some-crazy-feature` will be auto
labeled with "feature".

The possible labels are defined in `.github/pr-labeler-branches.yml`
whilst the action is defined in `.github/workflows/pr-labeler.yml`

For further documentation, check out: https://github.com/TimonVS/pr-labeler-action