### PR TITLE
add credentials related to https on ebs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ yarn-debug.log*
 yarn-error.log*
 .idea
 
+backend/.ebextensions/https*
+
 # Elastic Beanstalk Files
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+*pem
+*crt


### PR DESCRIPTION
I've been working on getting https working on the ebs-instance. This updates the .gitignore so that I dont commit our very secret secret key