### PR TITLE
Do not plot lines when recieving data points without GPS coordinates.

### DIFF
--- a/frontend/src/Components/Trackerinfo/HistoricTrackerMap.tsx
+++ b/frontend/src/Components/Trackerinfo/HistoricTrackerMap.tsx
@@ -80,14 +80,20 @@ const HistoricTrackerMap = ({ data }: props) => {
         }
         setPolylines(
             tempPolylines.map((x) => {
-                return (
-                    <Polyline
-                        positions={[
-                            [x[0].gps.lat, x[0].gps.lon],
-                            [x[1].gps.lat, x[1].gps.lon],
-                        ]}
-                    />
-                )
+                if (x[0].gps.lat !== '-9000' && x[1].gps.lat !== '-9000') {
+                    return (
+                        <Polyline
+                            positions={[
+                                [x[0].gps.lat, x[0].gps.lon],
+                                [x[1].gps.lat, x[1].gps.lon],
+                            ]}
+                        />
+                    )
+                }
+                // Eslint expects a return value. As no lines are to be plotted,
+                //  we return nothing and ignore the warning.
+                // eslint-disable-next-line array-callback-return
+                return
             })
         )
     }, [data])


### PR DESCRIPTION
When no GPS coordiantes are recieved in backend, the value for longitude
and latitude defaults too '-9000' When this values is recieved in
frontend, do not plot lines to and from this coordinate.